### PR TITLE
Let serverless core provide correct function name for logging policy.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class CustomRoles {
     };
   }
 
-  getLoggingPolicy(stackName, functionName) {
+  getLoggingPolicy(functionName) {
     const statements = [
       {
         Effect: 'Allow',
@@ -47,7 +47,7 @@ class CustomRoles {
               'arn:aws:logs',
               { Ref: 'AWS::Region' },
               { Ref: 'AWS::AccountId' },
-              `log-group:/aws/lambda/${stackName}-${functionName}:*`
+              `log-group:/aws/lambda/${functionName}:*`
             ]
           ]
         }]
@@ -62,7 +62,7 @@ class CustomRoles {
               'arn:aws:logs',
               { Ref: 'AWS::Region' },
               { Ref: 'AWS::AccountId' },
-              `log-group:/aws/lambda/${stackName}-${functionName}:*:*`
+              `log-group:/aws/lambda/${functionName}:*:*`
             ]
           ]
         }]
@@ -175,7 +175,7 @@ class CustomRoles {
       const functionObj = service.getFunction(functionName);
       const roleId = this.getRoleId(functionName);
 
-      const policies = [this.getLoggingPolicy(stackName, functionName)];
+      const policies = [this.getLoggingPolicy(functionObj.name)];
       if (sharedPolicy) {
         policies.push(sharedPolicy);
       }

--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -13,6 +13,13 @@ function createTestInstance(options) {
   options = options || {}; // eslint-disable-line no-param-reassign
 
   const functions = options.functions || {};
+  Object.keys(functions).map(functionName => {
+    // Serverless core provides function name automatically
+    // when user does not provide an explicit override.
+    functions[functionName].name = functions[functionName].name || `foo-dev-${functionName}`;
+    return true;
+  });
+
   return new CustomRoles({
     version: options.version || '1.12.0',
     service: {


### PR DESCRIPTION
An optional `name` parameter is supported by serverless. https://serverless.com/framework/docs/providers/aws/guide/functions/

This parameter is especially useful when auto-generated function names become too long (see CF limits https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html), and a different name can be given to comply with CF system limits.

Currently `serverless-plugin-custom-roles` assumes LoggingPolicy log-group naming convention to follow format of `stackName-functionName` which is correct **only** when function names are auto-generated and not explicitly overridden by user.

I've tested this change in production system already, without which custom-named function lost access to their CloudWatch logs, and with which access to logs was restored.

