### PR TITLE
Add support for AWS IAM boundaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ class CustomRoles {
     return this.getPolicyFromStatements('streams', statements);
   }
 
-  getRole(stackName, functionName, policies, managedPolicies) {
+  getRole(stackName, functionName, policies, managedPolicies, permissionsBoundary) {
     const role = {
       Type: 'AWS::IAM::Role',
       Properties: {
@@ -174,6 +174,10 @@ class CustomRoles {
 
     if (managedPolicies && managedPolicies.length) {
       role.Properties.ManagedPolicyArns = managedPolicies;
+    }
+
+    if (permissionsBoundary && permissionsBoundary.length) {
+      role.Properties.PermissionsBoundary = permissionsBoundary;
     }
 
     return role;
@@ -198,6 +202,18 @@ class CustomRoles {
     } else if (service.provider.iamRoleStatements) {
       sharedRoleStatements = service.provider.iamRoleStatements;
     }
+
+    let pb = null;
+
+    if (
+      service.provider.iam
+      && service.provider.iam.role
+      && service.provider.iam.role.permissionsBoundary) {
+      pb = service.provider.iam.role.permissionsBoundary;
+    } else if (service.provider.rolePermissionsBoundary) {
+      pb = service.provider.rolePermissionsBoundary;
+    }
+
     const sharedPolicy = this.getPolicyFromStatements('shared', sharedRoleStatements);
     const stackName = this.provider.naming.getStackName();
 
@@ -228,7 +244,7 @@ class CustomRoles {
           managedPolicies.push(VPC_POLICY);
         }
 
-        const roleResource = this.getRole(stackName, functionName, policies, managedPolicies);
+        const roleResource = this.getRole(stackName, functionName, policies, managedPolicies, pb);
 
         functionObj.role = roleId;
         set(service, `resources.Resources.${roleId}`, roleResource);

--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -750,7 +750,7 @@ describe('serverless-plugin-custom-roles', function() {
       sinon.assert.notCalled(instance.serverless.cli.log);
     });
 
-    it('should add a permission boundary when provider has one defined', function() {
+    it('should add a permissionsBoundary when provider has one defined', function() {
       const expectedPermissionsBoundary = 'TEST_PERMISSIONS_BOUNDARY';
       const instance = createTestInstance({
         provider: {
@@ -759,6 +759,35 @@ describe('serverless-plugin-custom-roles', function() {
               permissionsBoundary: expectedPermissionsBoundary
             }
           }
+        },
+        functions: {
+          function1: {}
+        }
+      });
+
+      instance.createRoles();
+
+      expect(instance)
+        .to.have.nested.property('serverless.service.resources')
+        .that.containSubset({
+          Resources: {
+            Function1LambdaFunctionRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                PermissionsBoundary: expectedPermissionsBoundary
+              }
+            }
+          }
+        });
+
+      sinon.assert.notCalled(instance.serverless.cli.log);
+    });
+
+    it('should add a rolePermissionsBoundary when provider has one defined', function() {
+      const expectedPermissionsBoundary = 'TEST_PERMISSIONS_BOUNDARY';
+      const instance = createTestInstance({
+        provider: {
+          rolePermissionsBoundary: expectedPermissionsBoundary
         },
         functions: {
           function1: {}

--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -749,5 +749,69 @@ describe('serverless-plugin-custom-roles', function() {
 
       sinon.assert.notCalled(instance.serverless.cli.log);
     });
+
+    it('should add a permission boundary when provider has one defined', function() {
+      const expectedPermissionsBoundary = 'TEST_PERMISSIONS_BOUNDARY';
+      const instance = createTestInstance({
+        provider: {
+          iam: {
+            role: {
+              permissionsBoundary: expectedPermissionsBoundary
+            }
+          }
+        },
+        functions: {
+          function1: {}
+        }
+      });
+
+      instance.createRoles();
+
+      expect(instance)
+        .to.have.nested.property('serverless.service.resources')
+        .that.containSubset({
+          Resources: {
+            Function1LambdaFunctionRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                PermissionsBoundary: expectedPermissionsBoundary
+              }
+            }
+          }
+        });
+
+      sinon.assert.notCalled(instance.serverless.cli.log);
+    });
+
+    it('should not add a permission boundary when provider has none', function() {
+      const expectedPermissionsBoundary = 'TEST_PERMISSIONS_BOUNDARY';
+      const instance = createTestInstance({
+        provider: {
+          iam: {
+            role: {}
+          }
+        },
+        functions: {
+          function1: {}
+        }
+      });
+
+      instance.createRoles();
+
+      expect(instance)
+        .to.have.nested.property('serverless.service.resources')
+        .that.not.containSubset({
+          Resources: {
+            Function1LambdaFunctionRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                PermissionsBoundary: expectedPermissionsBoundary
+              }
+            }
+          }
+        });
+
+      sinon.assert.notCalled(instance.serverless.cli.log);
+    });
   });
 });


### PR DESCRIPTION
# What does this do?

Add the ability for roles generated by this plugin to apply IAM boundaries on each role.

This supports both `provider.rolePermissionsBoundary` and `provider.iam.role.permissionsBoundary`.

# Why is this being done?

Some organizations wish to apply additional protections to roles using boundaries

# Reference

* [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html)
* [IAM Permissions For Functions - At glance](https://www.serverless.com/framework/docs/providers/aws/guide/iam#at-glance)
* [Serverless Framework Deprecations
 - Grouping IAM settings under provider.iam](https://www.serverless.com/framework/docs/deprecations#grouping-iam-settings-under-provideriam)